### PR TITLE
Implement changelog parsing and automatic releases

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,3 +34,4 @@ jobs:
         uses: zattoo/changelog@v2
         with:
           token: ${{ github.token }}
+          exclude: "CONTRIBUTING.md, LICENSE, .gitignore, .pg_format, .github/**/*, .vscode/**/*"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Validate changelog
         uses: zattoo/changelog@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          exclude: "CONTRIBUTING.md, .gitignore, .github/**/*"
+          token: ${{ github.token }}
+          exclude: "CONTRIBUTING.md, LICENSE, .gitignore, .pg_format, .github/**/*, .vscode/**/*"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,10 +1,8 @@
-name: CI
+name: PR checks
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
+    types: [opened, reopened, synchronize]
 
 jobs:
   build:
@@ -31,3 +29,8 @@ jobs:
 
       - name: Test
         run: supabase test db
+
+      - name: Validate changelog
+        uses: zattoo/changelog@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,3 +34,4 @@ jobs:
         uses: zattoo/changelog@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          exclude: "CONTRIBUTING.md, .gitignore, .github/**/*"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,4 +34,3 @@ jobs:
         uses: zattoo/changelog@v2
         with:
           token: ${{ github.token }}
-          exclude: "CONTRIBUTING.md, LICENSE, .gitignore, .pg_format, .github/**/*, .vscode/**/*"

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -48,7 +48,7 @@ jobs:
         if: ${{ steps.local_version.outputs.version != steps.remote_version.outputs.release }}
         uses: actions/create-release@v1.1.2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           tag_name: ${{ steps.local_version.outputs.version }}
           release_name: ${{ steps.local_version.outputs.version }}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -1,0 +1,61 @@
+name: Release and publish to database.dev
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release_publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: baptiste0928/cargo-install@v3
+        with:
+          crate: dbdev
+          git: https://github.com/supabase/dbdev.git
+
+      - name: Create dbdev credentials file
+        shell: bash
+        run: |
+          mkdir $HOME/.dbdev
+          echo '[registries.dbdev]\ntoken = "$MAPPED_DBDEV_TOKEN"' >> $HOME/.dbdev/credentials.toml
+        env:
+          MAPPED_DBDEV_TOKEN: ${{ secrets.DBDEV_TOKEN }}
+
+      - name: Parse local version
+        id: local_version
+        shell: bash
+        run: |
+          echo ::set-output name=version::v$(grep default_version pg_protect_columns.control | tr -d ' ' | cut -d '=' -f2)
+
+      - name: Parse remote version
+        id: remote_version
+        uses: pozetroninc/github-action-get-latest-release@v0.8.0
+        with:
+          repository: ${{ github.repository }}
+
+      - name: Parse changelog
+        if: ${{ steps.local_version.outputs.version != steps.remote_version.outputs.release }}
+        id: changelog
+        uses: mindsers/changelog-reader-action@v2.2.3
+        with:
+          version: ${{ steps.local_version.outputs.version }}
+          path: ./CHANGELOG.md
+
+      - name: Release
+        if: ${{ steps.local_version.outputs.version != steps.remote_version.outputs.release }}
+        uses: actions/create-release@v1.1.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.local_version.outputs.version }}
+          release_name: ${{ steps.local_version.outputs.version }}
+          body: ${{ steps.changelog.outputs.log_entry }}
+
+      - name: Publish
+        if: ${{ steps.local_version.outputs.version != steps.remote_version.outputs.release }}
+        shell: bash
+        run: |
+          dbdev publish

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -40,9 +40,6 @@ jobs:
         if: ${{ steps.local_version.outputs.version != steps.remote_version.outputs.release }}
         id: changelog
         uses: mindsers/changelog-reader-action@v2.2.3
-        with:
-          version: ${{ steps.local_version.outputs.version }}
-          path: ./CHANGELOG.md
 
       - name: Release
         if: ${{ steps.local_version.outputs.version != steps.remote_version.outputs.release }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.2] - 2024-07-03
+## [0.0.2] - 2024-07-04
 
 ### Changed
 - Minor readme fixes for installation instructions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2] - 2024-07-03
+
+### Changed
+- Minor readme fixes for installation instructions
+
 ## [0.0.1] - 2024-07-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.0.1] - 2024-07-02
+
 ### Added
 - Initial extension functions
 - Initial test suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1] - 2024-07-02
+### Added
+- Initial extension functions
+- Initial test suite

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,4 +8,4 @@ This package is automatically published on a merge to the `main` branch. If the 
 + A GitHub release will be created
 + The package will be published to database.dev
 
-Changelog entries should be written according to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) format. There is a PR check to ensure a changelog entry has been added in the correct format.
+Changelog entries should be written according to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) format. There is a PR check to ensure a changelog entry has been added in the correct format if project files have been changed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+## Writing changelog entries
+
+This package is automatically published on a merge to the `main` branch. If the package version has been bumped:
+
++ The changelog will be parsed for the latest entry
++ A GitHub release will be created
++ The package will be published to database.dev
+
+Changelog entries should be written according to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) format. There is a PR check to ensure a changelog entry has been added in the correct format.

--- a/pg_protect_columns--0.0.1--0.0.2.sql
+++ b/pg_protect_columns--0.0.1--0.0.2.sql
@@ -1,0 +1,2 @@
+-- Ensure this can only be called via `create extension`.
+\echo Use "CREATE EXTENSION pg_protect_columns" to load this file. \quit

--- a/pg_protect_columns.control
+++ b/pg_protect_columns.control
@@ -1,3 +1,3 @@
-default_version = 0.0.1
+default_version = 0.0.2
 comment = 'A set of postgres functions that allow you to protect columns that should not be updated.'
 relocatable = true


### PR DESCRIPTION
To get things up to speed, this PR adds:

- A changelog
- Contribution guidance
- Changelog validation
- Renames the workflows for clarity
- A release pipeline to database.dev

A changelog entry will be *required* if project source files are altered, and the latest entry in the changelog will be used for the release. I figured that was better than having folks needing to remember to change the default version in order to validate the changelog.

Closes #5 