### PR TITLE
Remove v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.2] - 2024-07-04
-
-### Changed
-- Minor readme fixes for installation instructions
-
 ## [0.0.1] - 2024-07-02
 
 ### Added

--- a/pg_protect_columns--0.0.1--0.0.2.sql
+++ b/pg_protect_columns--0.0.1--0.0.2.sql
@@ -1,2 +1,0 @@
--- Ensure this can only be called via `create extension`.
-\echo Use "CREATE EXTENSION pg_protect_columns" to load this file. \quit

--- a/pg_protect_columns.control
+++ b/pg_protect_columns.control
@@ -1,3 +1,3 @@
-default_version = 0.0.2
+default_version = 0.0.1
 comment = 'A set of postgres functions that allow you to protect columns that should not be updated.'
 relocatable = true


### PR DESCRIPTION
The release pipeline is working properly, but since `dbdev` isn't updating packages properly at the moment, the new version didn't actually bump there (from CI or from local). So instead of having the empty file for `0.0.1--0.0.2` I'm just going to remove it for now. It was only readme updates.